### PR TITLE
Allow agent to be specific in options.

### DIFF
--- a/lib/proxy-client.js
+++ b/lib/proxy-client.js
@@ -33,6 +33,7 @@ function ProxyClient(options) {
   this.rootUrl = this.rootUrl || options.rootUrl || 'http://localhost';
   this.logger = this.logger || options.logger || sawmill.createMill(this.constructor.name);
   this.timeout = this.timeout || options.timeout || 5000;
+  this.agent = this.agent || options.agent;
 
   this.headers = util._extend(this.headers || {}, options.headers);
 }
@@ -58,6 +59,7 @@ ProxyClient.prototype.getChild = function getChild(options) {
     child.rootUrl = options.rootUrl || child.rootUrl;
     child.logger = options.logger || child.logger;
     child.timeout = options.timeout || child.timeout;
+    child.agent = options.agent || child.agent;
     child.headers = util._extend(child.headers, options.headers);
   }
 
@@ -96,6 +98,7 @@ ProxyClient.prototype.request = function request(method, path) {
   var href = self.getUrl(path);
 
   return superagent(method, href)
+    .agent(self.agent || false)
     .set(self.headers)
     .timeout(self.timeout)
     .use(superagentThen)
@@ -162,6 +165,7 @@ ProxyClient.prototype.subapp = function subapp() {
       hostname: parsedUrl.hostname,
       port: parsedUrl.port,
       path: parsedUrl.path,
+      agent: self.agent,
       headers: util._extend(req.headers, {
         'Connection': 'Keep-Alive',
         'Host': parsedUrl.host,


### PR DESCRIPTION
An agent is required for connection pooling, which is useful for keeping HTTPS connections open over high latency networks to avoid costly TLS handshaking, for example.
